### PR TITLE
[FIX] Loupedeck version numbers

### DIFF
--- a/Scripts/Update-Loupedeck.ps1
+++ b/Scripts/Update-Loupedeck.ps1
@@ -19,11 +19,16 @@ $DownloadFileName = "latest-win.exe"
 Invoke-WebRequest -Uri $latestVersionUrl -OutFile $DownloadFileName
 $file = Get-ChildItem -Path $DownloadFileName
 $versionInfo = $file.VersionInfo.ProductVersion
-# strip according to semver
-$newVersion = $versionInfo -replace "(\d+\.\d+\.\d+).*", '$1'
 
-if($wingetVersions -eq $newVersion) {
-    Write-Output "No new version found"
+if ($null -eq $versionInfo) {
+    Write-Host "Could not find version info in file"
+    exit 1
+}
+
+Write-Host "Found latest version: $versionInfo"
+
+if ($wingetVersions.Contains($versionInfo)) {
+    Write-Host "No new version found"
     exit 0
 }
 
@@ -31,28 +36,28 @@ $fullDownloadURL = "https://download.loupedeck.com/software/latest/LoupedeckInst
 
 # check if full download URL is valid
 $fullDownloadURLResponse = Invoke-WebRequest -Uri $fullDownloadURL -UseBasicParsing -Method Head
-if($fullDownloadURLResponse.StatusCode -ne 200) {
-    Write-Output "Full download URL is not valid"
+if ($fullDownloadURLResponse.StatusCode -ne 200) {
+    Write-Host "Full download URL is not valid"
     exit 1
 }
 
 # Check for existing PRs
-$ExistingPRs = gh pr list --search "$($wingetPackage) version $($newVersion) in:title draft:false" --state 'all' --json 'title,url' --repo 'microsoft/winget-pkgs' | ConvertFrom-Json
+$ExistingPRs = gh pr list --search "$($wingetPackage) version $($versionInfo) in:title draft:false" --state 'all' --json 'title,url' --repo 'microsoft/winget-pkgs' | ConvertFrom-Json
 
-if ($wingetVersions -and ($wingetVersions -notmatch $newVersion) -and ($ExistingPRs.Count -eq 0)) {
+if ($wingetVersions -and ($wingetVersions -notmatch $versionInfo) -and ($ExistingPRs.Count -eq 0)) {
     gh repo sync $Env:WINGET_PKGS_FORK_REPO -b main
-    $prMessage = "Update version: $wingetPackage version $newVersion"
+    $prMessage = "Update version: $wingetPackage version $versionInfo"
     # getting latest wingetcreate file     
     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
     #architecture workaround: https://github.com/microsoft/winget-create/blob/main/doc/update.md
-    .\wingetcreate.exe update $wingetPackage -s -v $newVersion -u "$fullDownloadURL|x64" --prtitle $prMessage -t $gitToken
+    .\wingetcreate.exe update $wingetPackage -s -v $versionInfo -u "$fullDownloadURL|x64" --prtitle $prMessage -t $gitToken
 }
 else { 
-Write-Output "$foundMessage"
-if ($ExistingPRs.Count -gt 0) {
-    $ExistingPRs | ForEach-Object {
-        Write-Output "Found existing PR: $($_.title)"
-        Write-Output "-> $($_.url)"
+    Write-Host "$foundMessage"
+    if ($ExistingPRs.Count -gt 0) {
+        $ExistingPRs | ForEach-Object {
+            Write-Host "Found existing PR: $($_.title)"
+            Write-Host "-> $($_.url)"
+        }
     }
-}
 }


### PR DESCRIPTION
- fix: Version numbers need to match the exact file version info e.g. 5.8.1.1865 instead of 5.8.1.1865
- refactor: Write-Host instead of Write-Output